### PR TITLE
Allow Cross Origin Requests

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,6 +8,13 @@ micronaut:
     multipart:
       enabled: true
       max-file-size: 1000000
+
+    cors:
+      enabled: true
+      localhost-pass-through: true
+      configurations:
+        - '"${FRONTEND_URL:webcorc.informatik.kit.edu}"'
+      
   http.client.max-content-length: 1000000
 
 aws:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -13,7 +13,8 @@ micronaut:
       enabled: true
       localhost-pass-through: true
       configurations:
-        - '"${FRONTEND_URL:webcorc.informatik.kit.edu}"'
+        frontend:
+          - '"${FRONTEND_URL:webcorc.informatik.kit.edu}"'
       
   http.client.max-content-length: 1000000
 


### PR DESCRIPTION
Allow CORS Requests from localhost and Frontends under different domain configured via the environment variable FRONTEND_URL