### PR TITLE
Single-Statement verification

### DIFF
--- a/frontend/src/app/components/editor/statements/statement/statement.component.html
+++ b/frontend/src/app/components/editor/statements/statement/statement.component.html
@@ -44,6 +44,16 @@
             label="unverified"
           />
         }
+        <p-button
+          text
+          [icon]="isVerifying() ? 'pi pi-spin pi-spinner' : 'pi pi-check-circle'"
+          severity="secondary"
+          [disabled]="isVerifying()"
+          [style.cursor]="isVerifying() ? 'wait' : 'pointer'"
+          (click)="verifyStatement()"
+          [title]="isVerifying() ? 'Verifying...' : 'Verify this statement'"
+        >
+        </p-button>
         @if (_node.parent) {
           <p-button
             text

--- a/frontend/src/app/services/tree/tree.service.ts
+++ b/frontend/src/app/services/tree/tree.service.ts
@@ -413,6 +413,96 @@ export class TreeService {
     }
   }
 
+  /**
+   * Find a statement node by its statement ID
+   * @param id The ID of the statement to find
+   * @returns The statement node if found, undefined otherwise
+   */
+  public findStatementNodeById(id: string): AbstractStatementNode | undefined {
+    const nodes = this._statementNodes();
+    for (const node of nodes) {
+      if (node.statement.id === id) {
+        return node;
+      }
+      // Recursively search children
+      const found = this.findNodeInSubtree(node, id);
+      if (found) {
+        return found;
+      }
+    }
+    return undefined;
+  }
+
+  private findNodeInSubtree(
+    node: AbstractStatementNode,
+    id: string,
+  ): AbstractStatementNode | undefined {
+    for (const child of node.children) {
+      if (child) {
+        if (child.statement.id === id) {
+          return child;
+        }
+        const found = this.findNodeInSubtree(child, id);
+        if (found) {
+          return found;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Collect all nodes in the subtree starting from the given node (including the node itself)
+   * @param node The root node of the subtree
+   * @returns Array of all nodes in the subtree
+   */
+  public collectSubtreeNodes(node: AbstractStatementNode): AbstractStatementNode[] {
+    const nodes: AbstractStatementNode[] = [node];
+    for (const child of node.children) {
+      if (child) {
+        nodes.push(...this.collectSubtreeNodes(child));
+      }
+    }
+    return nodes;
+  }
+
+  /**
+   * Create a temporary formula from a statement node for verification
+   * @param node The statement node to verify
+   * @returns A temporary LocalCBCFormula with the statement as root
+   */
+  public createTempFormulaFromNode(node: AbstractStatementNode): LocalCBCFormula {
+    // Finalize the node to sync conditions
+    node.finalize();
+
+    let rootStatement: IRootStatement;
+
+    // If the node is already a ROOT type, use it directly
+    if (node.statement.type === "ROOT") {
+      rootStatement = node.statement as IRootStatement;
+    } else {
+      // Otherwise, wrap the statement in a RootStatement
+      rootStatement = new RootStatement(
+        node.statement.name || "temp",
+        node.statement.preCondition,
+        node.statement.postCondition,
+        node.statement,
+      );
+    }
+
+    // Create temporary formula with global context from root formula
+    const tempFormula = new LocalCBCFormula(
+      node.statement.name || "temp",
+      rootStatement,
+      this.rootFormula?.javaVariables || [],
+      this.rootFormula?.globalConditions || [],
+      this.rootFormula?.renamings || null,
+      false,
+    );
+
+    return tempFormula;
+  }
+
   public dump() {
     return {
       rootStatementNode: JSON.stringify(

--- a/frontend/src/app/services/tree/verification/verification.service.ts
+++ b/frontend/src/app/services/tree/verification/verification.service.ts
@@ -4,6 +4,8 @@ import { ProjectService } from "../../project/project.service";
 import { TreeService } from "../tree.service";
 import { IRootStatement } from "../../../types/statements/root-statement";
 import { ConsoleService } from "../../console/console.service";
+import { AbstractStatementNode } from "../../../types/statements/nodes/abstract-statement-node";
+import { IAbstractStatement } from "../../../types/statements/abstract-statement";
 
 /**
  * Service to distribute the verification result from the http response to the tree service.
@@ -66,6 +68,109 @@ export class VerificationService {
         `Verification failed: The formula "${formula.name}" could not be (completely) verified.`,
         "pi pi-times-circle",
       );
+    }
+  }
+
+  /**
+   * Handle verification result for a single statement and its subtree
+   * @param formula The formula returned from backend verification
+   * @param statementNode The statement node that was verified
+   * @param urn urn of the file being verified
+   */
+  public async nextStatement(
+    formula: LocalCBCFormula,
+    statementNode: AbstractStatementNode,
+    urn: string,
+  ) {
+    this.consoleService.finishLoading();
+
+    if (!formula.statement) {
+      this.consoleService.addStringInfo(
+        `Verification failed: No statement in response for "${statementNode.statement.name}".`,
+        "pi pi-times-circle",
+      );
+      return;
+    }
+
+    // Get statements from the verification result
+    const resultStatements = this.treeService.getStatementsFromFormula(formula);
+
+    // Collect all nodes in the subtree starting from the verified node
+    const subtreeNodes = this.treeService.collectSubtreeNodes(statementNode);
+
+    // Collect statements from subtree in order
+    const subtreeStatements: IAbstractStatement[] = [];
+    this.collectStatementsFromNode(statementNode, subtreeStatements);
+
+    // If the original node wasn't ROOT, the result will have a ROOT wrapper
+    // So we need to skip the ROOT statement in the result
+    let resultStartIndex = 0;
+    if (
+      statementNode.statement.type !== "ROOT" &&
+      resultStatements.length > 0 &&
+      resultStatements[0].type === "ROOT"
+    ) {
+      resultStartIndex = 1; // Skip the ROOT wrapper
+    }
+
+    // Match statements from result to nodes in the subtree by order
+    const minLength = Math.min(
+      resultStatements.length - resultStartIndex,
+      subtreeStatements.length,
+    );
+
+    for (let i = 0; i < minLength; i++) {
+      const resultStmt = resultStatements[resultStartIndex + i];
+      const subtreeStmt = subtreeStatements[i];
+
+      // Find the node corresponding to this statement
+      const node = subtreeNodes.find(
+        (n) => n.statement.id === subtreeStmt.id,
+      );
+      if (node) {
+        node.statement.isProven = resultStmt.isProven || false;
+      }
+    }
+
+    // Update the root statement node if it's a ROOT type
+    if (
+      formula.statement.type === "ROOT" &&
+      (formula.statement as IRootStatement).statement?.isProven
+    ) {
+      statementNode.statement.isProven = true;
+    }
+
+    // Refresh nodes to trigger UI update
+    this.treeService.refreshNodes();
+
+    // Show success/failure message
+    if (formula.isProven) {
+      this.consoleService.addStringInfo(
+        `Verification successful: The statement "${statementNode.statement.name}" and its subtree are verified.`,
+        "pi pi-check-circle",
+      );
+    } else {
+      this.consoleService.addStringInfo(
+        `Verification failed: The statement "${statementNode.statement.name}" or its subtree could not be (completely) verified.`,
+        "pi pi-times-circle",
+      );
+    }
+  }
+
+  /**
+   * Collect statements from a node and its subtree in order
+   * @param node The root node
+   * @param statements Array to collect statements into
+   */
+  private collectStatementsFromNode(
+    node: AbstractStatementNode,
+    statements: IAbstractStatement[],
+  ): void {
+    statements.push(node.statement);
+    for (const child of node.children) {
+      if (child) {
+        this.collectStatementsFromNode(child, statements);
+      }
     }
   }
 }


### PR DESCRIPTION
# Added individual statement verification

Adds a verify button to each statement in the editor, allowing to verify individual statements and their subtrees without verifying the entire formula.

## Before

- "Verify" button at the top that verified the entire formula tree
- Had to re-verify everything even if only one statement changed


## After

- Each statement now has its own verify button (next to the "verified/unverified" chip)
- Clicking it verifies that specific statement and all its child statements
- The button shows a spinner while verifying
- If verification fails (e.g., backend returns 500), the statement is marked as unverified
- Multiple statements can be verified at the same time
- The top-level "Verify" button still works as before
