### PR TITLE
escape key causes save of dialog

### DIFF
--- a/frontend/src/app/components/editor/condition/condition-editor/condition-editor.component.html
+++ b/frontend/src/app/components/editor/condition/condition-editor/condition-editor.component.html
@@ -49,12 +49,14 @@
     </div>
     <p-dialog
             [(visible)]="isDialogVisible"
-            [modal]="false"
+            [modal]="true"
             appendTo="body"
             [header]="placeholder"
             [style]="{ width: '40vw', height:'50vh'}"
             [contentStyle]="{ overflow: 'hidden'}"
-            closable="false"
+            closable="true"
+            [closeOnEscape]="true"
+            (onHide)="onDialogSaveClick()"
     >
         <div class="flex flex-col h-full">
             <textarea

--- a/frontend/src/app/components/editor/condition/condition-editor/condition-editor.component.ts
+++ b/frontend/src/app/components/editor/condition/condition-editor/condition-editor.component.ts
@@ -24,7 +24,7 @@ import {Dialog} from "primeng/dialog";
  */
 @Component({
     selector: 'app-condition-editor',
-    imports: [Textarea, IconField, InputIcon, FloatLabelModule, FormsModule, AsyncPipe, Button, ButtonGroup, Dialog],
+    imports: [Textarea, FloatLabelModule, FormsModule, AsyncPipe, Button, Dialog],
     templateUrl: './condition-editor.component.html',
     standalone: true,
     styleUrl: './condition-editor.component.css',


### PR DESCRIPTION
Text field dialog now closes when the user presses escape.
The state of the text field will automatically be saved.